### PR TITLE
Adds interface prefix option

### DIFF
--- a/ts/TableConverter.ts
+++ b/ts/TableConverter.ts
@@ -5,16 +5,21 @@ import * as _ from "lodash";
 import {Generic} from './FieldConverter';
 
 
-export class TableConversor {
+export interface TableConverterOptions {
+  interfacePrefix:string;
+}
+
+export class TableConverter {
 
     protected def:FieldDescription[];
+    protected options:TableConverterOptions;
     protected name:string;
     protected indentValue = 4;
 
-    constructor(name:string, def:FieldDescription[]) {
+    constructor(name:string, def:FieldDescription[], options: TableConverterOptions) {
         this.name = name;
         this.def = def;
-
+        this.options = options;
     }
 
     output() {
@@ -27,7 +32,7 @@ export class TableConversor {
 
     protected getInterfaceName():string {
         let camel = _.camelCase(this.name);
-        return 'I' + camel.charAt(0).toUpperCase() + camel.slice(1);
+        return this.options.interfacePrefix + camel.charAt(0).toUpperCase() + camel.slice(1);
     }
 
     protected getFieldsOutput():string {

--- a/ts/TypedRows.ts
+++ b/ts/TypedRows.ts
@@ -1,5 +1,5 @@
 import {Information} from './Information';
-import {TableConversor} from './TableConverter';
+import {TableConverter} from './TableConverter';
 import fs = require('fs');
 import * as async from "async";
 import mysql = require("mysql");
@@ -12,6 +12,7 @@ export interface TypedRowsOptions {
     database:string;
     host:string;
     port:string;
+    prefix:string;
 }
 
 export class TypedRows {
@@ -73,7 +74,11 @@ export class TypedRows {
             info.getTables((err, tables:string[]) => {
                 async.map(tables, (table:string, callback) => {
                     info.describe(table, (err, fields) => {
-                        const conversor = new TableConversor(table, fields);
+                        const conversor = new TableConverter(
+                          table,
+                          fields,
+                          {interfacePrefix: this.options.prefix}
+                        );
                         callback(err, conversor.output());
                     });
                 }, (err, outputs) => {

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -12,6 +12,7 @@ program
     .option('-d, --database <database>', 'database name')
     .option('-h, --host [host]', 'database host - Default 127.0.0.1', '127.0.0.1')
     .option('-p, --port [port]', 'database port - Default 3306', '3306')
+    .option('-px, --prefix [prefix]', 'interface prefix - Default I', 'I')
     .option('-o, --outfile <outfile>', 'Out file - Default ./TypedRows.ts', './TypedRows.ts')
     .parse(process.argv);
 
@@ -22,7 +23,8 @@ const options = {
     password: program.password,
     database: program.database,
     outfile: program.outfile,
-    port : program.port
+    port : program.port,
+    prefix : program.prefix
 };
 
 if (options.database === undefined) {

--- a/ts/test/TableConverterTest.ts
+++ b/ts/test/TableConverterTest.ts
@@ -1,0 +1,16 @@
+/// <reference path="../typings/globals/mocha/index.d.ts" />
+/// <reference path="../typings/globals/chai/index.d.ts" />
+import {TableConverter} from "../../js/TableConverter";
+import * as chai from 'chai';
+let assert = chai.assert;
+
+describe('TableConverter', () => {
+    let subject : TableConverter;
+
+    describe('#output', () => {
+        it('Should use interface prefix', () => {
+            subject = new TableConverter('person', [], {interfacePrefix: 'I'});
+            assert.include(subject.output(), 'IPerson');
+        });
+    });
+});


### PR DESCRIPTION
Because I'd love to distinguish the prefix used for database interfaces from other parts of my application, I suggest to add a `interfacePrefix` option.

### What has been done
- Added a prefix option in the CLI
- Renamed `TableConversor` to `TableConverter`
- Extended the `TableConverter` with `options`
- Added a test `TableConverterTest`

### How to test
When adding `--prefix=Db` to the CLI tool, the interfaces generated will be prefixed with that prefix.

```typescript
...
export interface DbPerson {
...
```