### PR TITLE
Add support for boolean type.

### DIFF
--- a/src/FieldConverter.ts
+++ b/src/FieldConverter.ts
@@ -45,8 +45,8 @@ export class Generic {
             return new String(field);
         }
         if (/tinyint\(1\)/ig.exec(type) !== null) {
-	        return new Boolean(field);
-	    }
+            return new Boolean(field);
+        }
         if (/int|integer|smalint|tinyint|mediumint|decimal|numeric|double|bigint|float|decimal\s*\(\s*([0-9]+)\s*\)/ig.exec(type) !== null) {
             return new Number(field);
         }

--- a/src/FieldConverter.ts
+++ b/src/FieldConverter.ts
@@ -44,6 +44,9 @@ export class Generic {
         if (/varchar\s*\(\s*([0-9]+)\s*\)/ig.exec(type) !== null) {
             return new String(field);
         }
+        if (/tinyint\(1\)/ig.exec(type) !== null) {
+			return new Boolean(field);
+		}
         if (/int|integer|smalint|tinyint|mediumint|decimal|numeric|double|bigint|float|decimal\s*\(\s*([0-9]+)\s*\)/ig.exec(type) !== null) {
             return new Number(field);
         }
@@ -80,5 +83,11 @@ export class Enum extends Generic {
     getType():string {
         let [, values] = /enum\s*\(\s*(.+)\s*\)/ig.exec(this.definition.Type);
         return values.split(',').join(' | ');
+    }
+}
+
+export class Boolean extends Generic {
+    getType():string {
+        return 'boolean';
     }
 }

--- a/src/FieldConverter.ts
+++ b/src/FieldConverter.ts
@@ -45,8 +45,8 @@ export class Generic {
             return new String(field);
         }
         if (/tinyint\(1\)/ig.exec(type) !== null) {
-			return new Boolean(field);
-		}
+	        return new Boolean(field);
+	    }
         if (/int|integer|smalint|tinyint|mediumint|decimal|numeric|double|bigint|float|decimal\s*\(\s*([0-9]+)\s*\)/ig.exec(type) !== null) {
             return new Number(field);
         }

--- a/src/test/FieldConverterTest.ts
+++ b/src/test/FieldConverterTest.ts
@@ -1,5 +1,5 @@
 import {FieldDescription} from "../Information";
-import {Generic, Datetime, Number, String, Enum} from '../FieldConverter';
+import {Generic, Datetime, Number, String, Enum, Boolean} from '../FieldConverter';
 import * as chai from 'chai';
 const assert = chai.assert;
 
@@ -48,6 +48,11 @@ describe('FieldConverter', () => {
             fieldDescription.Type = 'datetime';
             subject = Generic.factory(fieldDescription);
             assert.instanceOf(subject, Datetime);
+        });
+        it('should create a boolean type because tinyint(1)', () => {
+            fieldDescription.Type = 'tinyint(1)';
+            subject = Generic.factory(fieldDescription);
+            assert.instanceOf(subject, Boolean);
         });
         it('should create a date type number because int(11)', () => {
             fieldDescription.Type = 'int(11)';


### PR DESCRIPTION
**Description:**
This feature adds support for boolean type, which is used when field type is `tinyint(1)`.

**Why:**
The ORM I'm using is converting these fields to boolean values and having them as numbers can cause issues.